### PR TITLE
 Update TF message type 

### DIFF
--- a/ros-rviz-tf.html
+++ b/ros-rviz-tf.html
@@ -99,7 +99,7 @@
           this._topic = new ROSLIB.Topic({
             ros: this.ros,
             name: '/tf',
-            messageType: 'tf/tfMessage',
+            messageType: 'tf2_msgs/TFMessage',
           });
         }
 


### PR DESCRIPTION
It looks like `tf/tfMessage` has been deprecated since Hydro, so I updated to `tf2_msgs/TFMessage`. I've also updated this on https://github.com/jstnhuang/ros-rviz/pull/26.

Users may experience problems with either message type, depending on what's been registered with the `/tf` topic before. I was using the old message type because that's the type when I test with `roslaunch pr2_gazebo pr2_empty_world.launch`, I haven't investigated why. So if you use that to test this, you need to make sure `rvizweb` was launched and the TF option selected first.

I'm not sure what's the correct way to solve this issue. I suspect the answer is "you shouldn't be subscribing to `/tf` directly", but I couldn't find an alternative using robot-web-tools, so either there is a proper way of doing this which I don't know, or some features will need to be added to `ROSLIB.TFClient`.

@tfoote , do you have any insights?
