### PR TITLE
Adding frame prefix to tf component.

### DIFF
--- a/ros-rviz-tf.html
+++ b/ros-rviz-tf.html
@@ -23,6 +23,8 @@
         color: var(--paper-red-500);
       }
     </style>
+    <paper-input label="TF prefix" value="{{tfPrefix}}"></paper-input>
+
     <template is="dom-repeat" items="[[_tfs]]">
       <div class="layout horizontal center">
         <paper-checkbox on-change="_toggleFrame" checked={{item.visible}} value={{item.frame}}>
@@ -44,6 +46,10 @@
         },
         ros: Object,
         tfClient: Object,
+        tfPrefix: {
+          type: String,
+          value: '',
+        },
         viewer: Object,
         _tfs: {
           type: Array,
@@ -51,6 +57,10 @@
         },
         _topic: Object,
       },
+
+      observers: [
+        '_optionsChanged(tfPrefix)',
+      ],
 
       ready: function() {
         this._updateDisplay();
@@ -78,6 +88,12 @@
         for (var i in this._tfs) {
           this._toggleTf(i, true);
         }
+      },
+
+      _optionsChanged(tfPrefix) {
+        this.hide();
+        this._tfs = [];
+        this._updateDisplay();
       },
 
       _toggleTf: function(index, show) {
@@ -111,7 +127,11 @@
 
       _onTf: function(that, msg) {
         for (var t of msg.transforms) {
-          that._addFrame(t.child_frame_id);
+          // Only add frames starting with the configured prefix.
+          if (t.header.frame_id.startsWith(that.tfPrefix) ||
+              t.child_frame_id.startsWith(that.tfPrefix)) {
+            that._addFrame(t.child_frame_id);
+          }
         }
       },
 


### PR DESCRIPTION
This PR should address https://github.com/osrf/rvizweb/issues/7.

In the following example, I have 5 frames: `map` (fixed frame), `robot_1/base_link`, `robot_2/base_link`, `robot_1/head`, `robot_2/head`. When the prefix is `robot`, I can see all frames starting with `robot*`. Note that when I change the prefix to `robot_1` or `robot_2`, two frames disappear and the other two stay.

![output_big_2](https://user-images.githubusercontent.com/2480899/49746250-8cea1f80-fc7f-11e8-8069-34b1edfca488.gif)

@chapulina PTAL.