### PR TITLE
Getting global config from ROS parameter when connecting to ROS.

### DIFF
--- a/ros-rviz.html
+++ b/ros-rviz.html
@@ -441,12 +441,29 @@ Example:
       },
 
       _rosChanged: function() {
+        var that = this;
         this._tfClient = new ROSLIB.TFClient({
           ros: this.ros,
           angularThres: 0.01,
           fixedFrame: this.config.globalOptions.fixedFrame,
           transThres: 0.01,
           rate: 10.0
+        });
+
+        this._configParam = new ROSLIB.Param({
+          ros: this.ros,
+          name: '/rvizweb/global_config'
+        });
+
+        this._configParam.get(function(value) {
+          if (value != null) {
+            try {
+              that.$.configText.value = value;
+              that._applyConfigText();
+            } catch (ex) {
+              console.log('Could not load configuration: ', value);
+            }
+          }
         });
       },
 


### PR DESCRIPTION
See https://github.com/osrf/rvizweb/issues/10.

The configuration will be added to the launchfile in `rvizweb` so that it gets pre-loaded to the parameter server. Modifying the configuration calls the callbacks of the components, so if the configuration has extra components (e.g. image, grid, etc) they will show up properly when reading the parameter.