### PR TITLE
Adding solid background to image when no image is received

### DIFF
--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -110,6 +110,8 @@
             messageType : _transportHints[this.transport_hints].type
         });
 
+        this._initCanvas(canvas, context);
+
         let updatingImage = false;
 
         this._imageTopic.subscribe(function(message) {
@@ -170,6 +172,16 @@
           document.onmousemove = null;
         }
     },
+
+    _initCanvas: function(canvas, context) {
+        context.fillStyle = "black";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+
+        context.font = "30pt Roboto";
+        context.fillStyle = "white";
+        context.fillText("No image", 55, 240);
+    },
+
     });
   </script>
 </dom-module>


### PR DESCRIPTION
Solves https://github.com/osrf/rvizweb/issues/15.

This is how the viewer looks when no image is received:
![screenshot from 2019-01-25 18-03-13](https://user-images.githubusercontent.com/2480899/51772818-c6f67000-20cb-11e9-8833-4fc5e569af93.png)

This is how it looks when the image stream is present (background color is transparent):
![screenshot from 2019-01-25 18-02-57](https://user-images.githubusercontent.com/2480899/51772830-ceb61480-20cb-11e9-9752-4832c1ea967f.png)

If the topic is changed and no image is received, the viewer will go back to its "no image" state. 
If images stop arriving without changing the topic, the last one that arrived will be displayed (rviz-like behavior).