### PR TITLE
Fix for image display

### DIFF
--- a/ros-rviz-display.html
+++ b/ros-rviz-display.html
@@ -34,6 +34,7 @@
       }
       #collapse {
         padding: 0px 10px;
+        display: block;
       }
       #header {
         cursor: pointer;

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -7,6 +7,22 @@
 
 <dom-module id="ros-rviz-image">
   <template>
+    <style>
+      #image_stream {
+        float: left;
+        margin-left: 105%;
+      }
+      #canvas_div {
+        position: fixed;
+        z-index: 9;
+        background-color: transparent;
+      }
+    </style>
+    <div id="image_stream">
+      <div id="canvas_div" title="[[topic]]">
+        <canvas id="xy_image" width="280px;" height="280px;"/>
+      </div>
+    </div>
     <paper-input label="Image topic" value="{{topic}}"></paper-input>
     <paper-dropdown-menu id="transport_hints_dropdown" label="Transport hints" on-iron-select="transportHintSelected">
       <paper-listbox slot="dropdown-content" class="dropdown-content" selected="0">
@@ -14,11 +30,6 @@
         <paper-item>CompressedDepth</paper-item>
       </paper-listbox>
     </paper-dropdown-menu>
-    <div style="position: relative;">
-      <div id="canvas_div" style="position: fixed; z-index: 9; background-color: transparent;" title="[[topic]]">
-        <canvas id="xy_image" width="280px;" height="280px;"/>
-      </div>
-    </div>
   </template>
   <script>
     const _transportHints = {

--- a/ros-rviz.html
+++ b/ros-rviz.html
@@ -59,6 +59,7 @@ Example:
       }
       #sidebar {
         height: 100%;
+        display: block;
       }
       #displays {
         width: 300px;


### PR DESCRIPTION
Solves https://github.com/osrf/rvizweb/issues/28.

Here's an example showing the fix with a Turtlebot staring at a container in Gazebo:

![Screenshot from 2019-03-21 18-25-04](https://user-images.githubusercontent.com/2480899/54786219-127a5580-4c07-11e9-907f-68737ccd4e92.png)

![output](https://user-images.githubusercontent.com/2480899/54786223-173f0980-4c07-11e9-88a5-2e207a13cdd4.gif)

I still need to adjust one detail, which is where the image is displayed by default when adding the control at first; @chapulina please hold on the review for now.