### PR TITLE
Adding support for tf_static.

### DIFF
--- a/ros-rviz-tf.html
+++ b/ros-rviz-tf.html
@@ -56,6 +56,8 @@
           value: []
         },
         _topic: Object,
+        _static_topic: Object,
+        _subscribed_frames: Object,
       },
 
       observers: [
@@ -117,10 +119,22 @@
             name: '/tf',
             messageType: 'tf2_msgs/TFMessage',
           });
+
+          this._static_topic = new ROSLIB.Topic({
+            ros: this.ros,
+            name: '/tf_static',
+            messageType: 'tf2_msgs/TFMessage',
+          });
         }
 
+        this._subscribed_frames = new Set();
         var that = this;
+
         this._topic.subscribe(function(msg) {
+          that._onTf(that, msg);
+        });
+
+        this._static_topic.subscribe(function(msg) {
           that._onTf(that, msg);
         });
       },
@@ -188,9 +202,12 @@
 
       _addFrame: function(frame) {
         that = this;
-        this.tfClient.subscribe(frame, function(tf) {
-          that._callback(that, frame, tf);
-        });
+        if (!this._subscribed_frames.has(frame)) {
+          this._subscribed_frames.add(frame);
+          this.tfClient.subscribe(frame, function(tf) {
+            that._callback(that, frame, tf);
+          });
+        }
       },
 
       _toggleFrame: function(e) {


### PR DESCRIPTION
Closes https://github.com/osrf/rvizweb/issues/30.

This also includes a small improvement so as not to subscribe repeatedly to the same frames.

Turtlebot before this patch (only base and wheels):
![Screenshot from 2019-03-28 12-57-28](https://user-images.githubusercontent.com/2480899/55177231-81086780-5161-11e9-8b9f-d2ef253289ba.png)

Turtlebot with this patch:
![Screenshot from 2019-03-28 12-56-43](https://user-images.githubusercontent.com/2480899/55177249-8cf42980-5161-11e9-9ed2-b61284d8136c.png)
